### PR TITLE
refactor: 💡 replace compromised webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Generally, you'll want to do two things while developing:
 - Get the Lambda running locally with a local SNS topic that you can publish events to
 - Publish events to the SNS topic to trigger the Lambda
 
-To get the Lambda running for the first time, run `yarn` in the project root to install the necessary dependencies. Then, simply run:
+To get the Lambda running for the first time, run `yarn` in the project root to install the necessary dependencies. You'll also need to export a value for `SLACK_WEBHOOK_URL` to your local environment (if you want to actually post to Slack, you'll need to get this value from 1Password).
+
+Then, simply run:
 ```
 make run-dev
 ```

--- a/cloudwatch_sns_to_slack/constants.py
+++ b/cloudwatch_sns_to_slack/constants.py
@@ -9,6 +9,4 @@ HEADERS = {
     'Content-Type': 'application/json',
 }
 
-POST_TO_SLACK_WEBHOOK = 'https://hooks.slack.com/services/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'
-
 DEV_SNS_ARN = 'arn:aws:sns:sa-east-1:123456789012:test-topic'

--- a/cloudwatch_sns_to_slack/handler.py
+++ b/cloudwatch_sns_to_slack/handler.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from os import getenv
 
 import requests
 
@@ -8,13 +9,14 @@ from cloudwatch_sns_to_slack.constants import (
     DEV_SNS_ARN,
     GENERIC_ERROR_MESSAGE,
     HEADERS,
-    POST_TO_SLACK_WEBHOOK,
     SERVICE_NAME
 )
 
 
 logger = logging.getLogger(SERVICE_NAME)
 logger.setLevel(logging.INFO)
+
+SLACK_WEBHOOK_URL = getenv('SLACK_WEBHOOK_URL')
 
 
 def _safe_get_sns_message_as_json(sns_message):
@@ -58,7 +60,7 @@ def _get_severity(sns_message):
 
 def _post(data):
     response = requests.post(
-        POST_TO_SLACK_WEBHOOK,
+        SLACK_WEBHOOK_URL,
         headers=HEADERS,
         data=json.dumps(data),
     )

--- a/serverless.yml
+++ b/serverless.yml
@@ -25,6 +25,8 @@ functions:
     name: cloudwatch-sns-to-slack
     description: Reads messages posted to SNS by Cloudwatch and publish them to the appropriate Slack channel
     runtime: python3.8
+    environment:
+      SLACK_WEBHOOK_URL: ${env:SLACK_WEBHOOK_URL}
     package:
       exclude:
         - ./** # We are excluding everything and then only including what we need so we reduce our lambda size


### PR DESCRIPTION
oops! I made this repo public and Slack sent me this message 5 mins after saying that they'd replaced our now compromised webhook. Now I'm picking up the new webhook URL (in 1Pass and configured in CircleCI) from the env var `SLACK_WEBHOOK_URL`. 