### PR TITLE
fix: 🐛 just load json like a normal person

### DIFF
--- a/resources/example_cloudwatch_sns_message.json
+++ b/resources/example_cloudwatch_sns_message.json
@@ -1,6 +1,6 @@
 {
     "AlarmName": "Example alarm name",
-    "AlarmDescription": "Example alarm description.",
+    "AlarmDescription": "Example alarm description. It's a tricky one with an apostrophe in it!",
     "AWSAccountId":"000000000000",
     "NewStateValue": "ALARM",
     "NewStateReason":"Threshold Crossed: 1 datapoint (10.0) was greater than or equal to the threshold (1.0).",

--- a/resources/sns_publish.py
+++ b/resources/sns_publish.py
@@ -14,5 +14,5 @@ with open(f'{SCRIPT_DIR}/example_cloudwatch_sns_message.json') as json_file:
 sns = boto3.client('sns', endpoint_url='http://127.0.0.1:4002')
 
 sns.publish(TopicArn=DEFAULT_TOPIC_ARN,
-            Message=str(CLOUDWATCH_ALARM_MESSAGE_TEMPLATE),
+            Message=json.dumps(CLOUDWATCH_ALARM_MESSAGE_TEMPLATE),
             Subject='ALARM: "Example alarm name" in South America (Sao Paulo)')

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,6 +27,7 @@ functions:
     runtime: python3.8
     environment:
       SLACK_WEBHOOK_URL: ${env:SLACK_WEBHOOK_URL}
+      RUNNING_IN_PROD: true
     package:
       exclude:
         - ./** # We are excluding everything and then only including what we need so we reduce our lambda size


### PR DESCRIPTION
OMG this was so annoying to figure out.... But basically the way I was loading SNS messages into the local SNS queue for the dev environment was different than what CloudWatch actually does when it publishes messages, so I had to do all this weird treatment of the CloudWatch SNS message when reading it in the Lambda (really only for the local env, this wasn't a problem in prod). But then my weird treatment (which involved replacing all `'` with `"`) caused a bug when the message content contained a `'`. 

So the real fix here was just to load things properly in the dev setup and then go back to a good ol' `json.loads(sns_message)`

Also I added an env var to the prod Lambda so that the Lambda can determine when it's deployed in prod or not (and thus automatically send only to the #test_channel when you're developing locally).
