### PR TITLE
chore: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+*    @pearsonhenri
+


### PR DESCRIPTION
Reference for how this works here: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners

When opening PRs on draft mode nothing happens, when opening PRs/marking them as ready to review, the codeowners will get automatically assigned as reviewers.