### PR TITLE
fix: add closing brace

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -42,7 +42,7 @@ functions:
       - sns: ${ssm:/cloudwatch_sns_to_slack/area-51-aws} # delete after https://github.com/legiti/canaveral/pull/467 is applied/merges
       - sns: ${ssm:/cloudwatch_sns_to_slack/integration-alerts}
       - sns: ${ssm:/cloudwatch_sns_to_slack/mlplatform-alerts}
-      - sns: ${ssm:/cloudwatch_sns_to_slack/modelagem-alerts
+      - sns: ${ssm:/cloudwatch_sns_to_slack/modelagem-alerts}
       - sns: ${ssm:/cloudwatch_sns_to_slack/sre-alerts}
       - sns: ${ssm:/cloudwatch_sns_to_slack/data-quality-alerts}
       - sns: ${ssm:/cloudwatch_sns_to_slack/platform-alerts}


### PR DESCRIPTION
deployment failed due to this syntax error... https://sa-east-1.console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/events?filteringStatus=active&filteringText=&viewNested=true&hideStacks=false&stackId=arn%3Aaws%3Acloudformation%3Asa-east-1%3A495260634483%3Astack%2Fcloudwatch-sns-to-slack-prod%2Fe94872c0-ced4-11eb-9189-0ab8f92e623e